### PR TITLE
Add font sizing controls, deadline display, and OG metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,16 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
+    <meta
+      name="description"
+      content="締め切りまでの残り時間を表示するシンプルなカウントダウンタイマー。"
+    />
+    <meta property="og:title" content="締め切りタイマー" />
+    <meta
+      property="og:description"
+      content="締め切り日時までの残り時間をわかりやすく表示します。"
+    />
+    <meta property="og:type" content="website" />
     <title>締め切りタイマー</title>
     <link rel="stylesheet" href="style.css" />
   </head>
@@ -10,7 +20,13 @@
 
     <main class="container">
       <div id="label" class="label"></div>
+      <div id="deadline" class="deadline"></div>
       <div id="timer" class="timer">--:--:--:--</div>
+      <div class="controls" aria-label="フォントサイズ調整">
+        <button type="button" class="font-button" id="fontDecrease">A-</button>
+        <button type="button" class="font-button" id="fontReset">標準</button>
+        <button type="button" class="font-button" id="fontIncrease">A+</button>
+      </div>
     </main>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -14,10 +14,32 @@ const LABEL_TEXT = "❣卒論提出まで❣";
 
 const timerEl = document.getElementById("timer");
 const labelEl = document.getElementById("label");
+const deadlineEl = document.getElementById("deadline");
 const toggleBtn = document.getElementById("themeToggle");
+const fontDecreaseBtn = document.getElementById("fontDecrease");
+const fontResetBtn = document.getElementById("fontReset");
+const fontIncreaseBtn = document.getElementById("fontIncrease");
 const body = document.body;
+const root = document.documentElement;
 
 labelEl.textContent = LABEL_TEXT;
+
+/* =========================
+   締切日時表示
+   ========================= */
+
+function formatDeadline(date) {
+  return date.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+deadlineEl.textContent = `締め切り日時: ${formatDeadline(DEADLINE)}`;
 
 /* =========================
    テーマ切り替え
@@ -26,6 +48,45 @@ labelEl.textContent = LABEL_TEXT;
 toggleBtn.addEventListener("click", () => {
   body.classList.toggle("dark");
   body.classList.toggle("light");
+});
+
+/* =========================
+   フォントサイズ調整
+   ========================= */
+
+const FONT_SCALE = {
+  min: 0.8,
+  max: 1.4,
+  step: 0.1,
+  default: 1,
+};
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function setFontScale(scale) {
+  const nextScale = clamp(scale, FONT_SCALE.min, FONT_SCALE.max);
+  root.style.setProperty("--font-scale", nextScale.toFixed(2));
+}
+
+function getFontScale() {
+  const current = parseFloat(
+    getComputedStyle(root).getPropertyValue("--font-scale"),
+  );
+  return Number.isNaN(current) ? FONT_SCALE.default : current;
+}
+
+fontDecreaseBtn.addEventListener("click", () => {
+  setFontScale(getFontScale() - FONT_SCALE.step);
+});
+
+fontIncreaseBtn.addEventListener("click", () => {
+  setFontScale(getFontScale() + FONT_SCALE.step);
+});
+
+fontResetBtn.addEventListener("click", () => {
+  setFontScale(FONT_SCALE.default);
 });
 
 /* =========================

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
   --bg-dark: #242424;
   --text-light: #f2f2f2;
   --text-dark: #1a1a1a;
+  --font-scale: 1;
 }
 
 body {
@@ -31,15 +32,48 @@ body.dark {
 }
 
 .label {
-  font-size: 1.6rem;
+  font-size: calc(1.6rem * var(--font-scale));
   margin-bottom: 1rem;
   opacity: 0.8;
 }
 
+.deadline {
+  font-size: calc(1rem * var(--font-scale));
+  margin-bottom: 1.5rem;
+  opacity: 0.7;
+}
+
 .timer {
-  font-size: clamp(3rem, 8vw, 6rem);
+  font-size: calc(clamp(3rem, 8vw, 6rem) * var(--font-scale));
   font-weight: 700;
   letter-spacing: 0.05em;
+}
+
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 1.5rem;
+}
+
+.font-button {
+  border: 1px solid currentColor;
+  background: transparent;
+  color: inherit;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+.font-button:hover {
+  opacity: 0.8;
+  transform: translateY(-1px);
+}
+
+.font-button:active {
+  transform: translateY(0);
 }
 
 /* テーマ切替ボタン */


### PR DESCRIPTION
### Motivation
- ユーザーが締め切り日時を確認できるようにページ上に締め切り日時を表示し、フォントサイズを調整できるUIを追加するための変更です。  
- SNSシェア時に説明が出るように簡易的なOG/descriptionメタを設定するための変更です。

### Description
- `index.html` に `description` と基本的な `og:` メタタグを追加しましたと、締め切り表示用の `#deadline` 要素とフォントサイズ調整ボタン群を追加しました。  
- `script.js` に締め切り日時の整形表示を行う `formatDeadline` と `deadlineEl.textContent` の設定を追加し、フォントスケール制御のための変数 `FONT_SCALE`、`setFontScale` / `getFontScale` とボタンイベントハンドラを実装しました。  
- `style.css` に `--font-scale` 変数を追加し、`label`/`deadline`/`timer` のフォントサイズをスケーリングするように変更し、フォントボタンのスタイルを追加しました。

### Testing
- 起動確認として `python -m http.server 8000` を実行してサイトを配信し起動は成功しました.  
- Playwright を使って `http://127.0.0.1:8000/index.html` を開きページのスクリーンショットを取得するスクリプトを実行し、`artifacts/deadline-timer.png` が出力されました（成功）。  
- これ以外の自動化されたユニットテストは実行していません。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696901c04bc48327a6ce8f6b899338f5)