### PR TITLE
fix: 秒境界同期の補正ロジック追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
     <script src="scripts/dom.js"></script>
     <script src="scripts/theme.js"></script>
     <script src="scripts/font-scale.js"></script>
+    <script src="scripts/clock.js"></script>
     <script src="scripts/timer.js"></script>
     <script src="scripts/app.js"></script>
   </body>

--- a/scripts/clock.js
+++ b/scripts/clock.js
@@ -1,0 +1,32 @@
+/* =========================
+   時刻同期ユーティリティ
+   ========================= */
+
+window.App = window.App || {};
+
+App.clock = {
+  anchorUnixMs: Date.now(),
+  anchorPerfMs: performance.now(),
+  // 一定間隔でアンカーを再同期して長期ドリフトを抑える
+  resyncIntervalMs: 60 * 1000,
+  lastResyncMs: Date.now(),
+  syncAnchors() {
+    App.clock.anchorUnixMs = Date.now();
+    App.clock.anchorPerfMs = performance.now();
+    App.clock.lastResyncMs = App.clock.anchorUnixMs;
+  },
+  nowMs() {
+    // Date.now の変化を performance.now と合成し，イベントループ遅延の影響を緩和
+    const elapsedMs = performance.now() - App.clock.anchorPerfMs;
+    return App.clock.anchorUnixMs + elapsedMs;
+  },
+  calcNextBoundaryDelay(nowMs) {
+    // 秒境界の補正数式: delay = 1000 - (nowMs % 1000)
+    return 1000 - (nowMs % 1000);
+  },
+  maybeResync(nowMs) {
+    if (nowMs - App.clock.lastResyncMs >= App.clock.resyncIntervalMs) {
+      App.clock.syncAnchors();
+    }
+  },
+};

--- a/scripts/timer.js
+++ b/scripts/timer.js
@@ -5,6 +5,8 @@
 window.App = window.App || {};
 
 App.timer = {
+  lastTotalSeconds: null,
+  timeoutId: null,
   formatDeadline(date) {
     return date.toLocaleString("ja-JP", {
       year: "numeric",
@@ -16,10 +18,17 @@ App.timer = {
     });
   },
   updateTimer() {
-    const now = new Date();
-    const diff = Math.max(0, App.config.deadline - now);
+    const nowMs = App.clock.nowMs();
+    const diff = Math.max(0, App.config.deadline.getTime() - nowMs);
 
     const totalSeconds = Math.floor(diff / 1000);
+
+    // 同一秒内での再描画を避けて端末間の表示差分を抑える
+    if (App.timer.lastTotalSeconds === totalSeconds) {
+      return;
+    }
+
+    App.timer.lastTotalSeconds = totalSeconds;
 
     const days = Math.floor(totalSeconds / 86400);
     const hours = Math.floor((totalSeconds % 86400) / 3600);
@@ -33,6 +42,18 @@ App.timer = {
       `${String(seconds).padStart(2, "0")}`;
 
     App.timer.updateTimerColor(seconds);
+  },
+  scheduleTick() {
+    App.timer.updateTimer();
+
+    const nowMs = App.clock.nowMs();
+    App.clock.maybeResync(nowMs);
+
+    // 次の秒境界に合わせて再実行してズレを最小化
+    // 補正式: delay = 1000 - (nowMs % 1000)
+    const delay = App.clock.calcNextBoundaryDelay(nowMs);
+
+    App.timer.timeoutId = setTimeout(App.timer.scheduleTick, delay);
   },
   updateTimerColor(seconds) {
     // 秒数に応じて 0–360 の色相を回す
@@ -48,7 +69,10 @@ App.timer = {
       `hsl(${hue}, ${saturation}%, ${lightness}%)`;
   },
   start() {
+    // 初期化時は即時描画し，次の秒境界から同期更新
+    App.clock.syncAnchors();
+    App.timer.lastTotalSeconds = null;
     App.timer.updateTimer();
-    setInterval(App.timer.updateTimer, 1000);
+    App.timer.scheduleTick();
   },
 };


### PR DESCRIPTION
<h1>PR: 秒境界同期型タイマーへの刷新と合成時刻モデルの導入</h1><h2>概要</h2><p>本PRは，タイマー更新機構を<br><strong>固定周期ポーリング（<code inline="">setInterval(1000)</code>）＋即値時刻取得（<code inline="">Date</code>）</strong><br>から，<br><strong>秒境界同期スケジューリング＋合成時刻モデル（<code inline="">Date.now</code> × <code inline="">performance.now</code>）</strong><br>へと置き換えるものである．</p><p>本変更の目的は，以下を同時に満たすことである．</p><ul><li><p>秒境界に対して一貫した表示更新</p></li><li><p>イベントループ遅延・タブスロットリング耐性</p></li><li><p>端末差・実行環境差による表示秒数の非決定性の低減</p></li><li><p>不要な再描画（同一秒内）を理論的に排除</p></li></ul><hr><h2>問題設定（従来実装の数理的欠陥）</h2><p>従来の更新方式は</p><p>$$<br>t_n = t_0 + n \cdot 1000 + \varepsilon_n<br>$$</p><p>という実行時刻列を暗黙に仮定していた．<br>ここで，</p><ul><li><p>$$t_0$$ は初回 <code inline="">setInterval</code> 実行時刻</p></li><li><p>$$\varepsilon_n$$ はイベントループ遅延・OSスケジューラ・タブ状態に依存する誤差</p></li></ul><p>である．<br>一般に $$\varepsilon_n$$ は</p><p>$$<br>\varepsilon_n \neq 0,\quad<br>\varepsilon_n \text{ は累積しうる}<br>$$</p><p>ため，実際の更新時刻は<strong>秒境界と非同期</strong>になる．<br>その結果，</p><ul><li><p>秒切り替わり前後で表示が揺れる</p></li><li><p>同一「論理秒」に対し複数回描画が走る</p></li><li><p>端末間で $$\lfloor (deadline - now)/1000 \rfloor$$ の評価結果が異なる</p></li></ul><p>という問題が発生する．</p><hr><h2>解法の全体像</h2><p>本PRでは，以下の3要素を組み合わせたモデルを採用する．</p><ol><li><p><strong>合成時刻モデル</strong></p></li><li><p><strong>秒境界同期スケジューリング</strong></p></li><li><p><strong>秒単位状態不変条件による描画抑制</strong></p></li></ol><hr><h2>1. 合成時刻モデル（Composite Clock）</h2><h3>定義</h3><p>時刻を以下で定義する．</p><p>$$<br>t_{\text{now}} =<br>t_{\text{anchor}}^{\text{unix}}<br>+<br>\left(<br>t^{\text{perf}} - t_{\text{anchor}}^{\text{perf}}<br>\right)<br>$$</p><p>ここで，</p><ul><li><p>$$t_{\text{anchor}}^{\text{unix}} = \text{Date.now()}$$</p></li><li><p>$$t_{\text{anchor}}^{\text{perf}} = \text{performance.now()}$$</p></li><li><p>$$t^{\text{perf}}$$ は現在の <code inline="">performance.now()</code></p></li></ul><p>である．</p><h3>性質</h3><ul><li><p>$$t^{\text{perf}}$$ は単調増加（monotonic）</p></li><li><p>$$t_{\text{anchor}}^{\text{unix}}$$ は絶対時刻基準</p></li><li><p>差分計算に <code inline="">Date.now()</code> を直接使わないため，<br>システム時刻取得ジッタの影響を局所化できる</p></li></ul><p>従って，</p><p>$$<br>\frac{d t_{\text{now}}}{d t^{\text{perf}}} = 1<br>$$</p><p>が成立し，<strong>表示用時刻として滑らかな連続性</strong>を持つ．</p><hr><h2>2. 秒境界同期スケジューリング</h2><h3>秒境界の定義</h3><p>任意の時刻 $$t$$ に対し，次の秒境界までの遅延 $$\Delta t$$ を</p><p>$$<br>\Delta t = 1000 - (t \bmod 1000)<br>$$</p><p>と定義する．</p><h3>更新スケジュール</h3><p>更新時刻列 $${s_k}$$ を次で定義する．</p><p>$$<br>s_{k+1} = s_k + \Delta t_k<br>$$</p><p>$$<br>\Delta t_k = 1000 - (t_k \bmod 1000)<br>$$</p><p>これにより，各更新は理想的に</p><p>$$<br>t \equiv 0 \pmod{1000}<br>$$</p><p>近傍で実行される．</p><h3>利点</h3><ul><li><p>遅延が発生しても次回更新は<strong>再び秒境界へ収束</strong></p></li><li><p>$$\varepsilon$$ が累積しない</p></li><li><p>秒切り替わりと描画タイミングが一致しやすい</p></li></ul><hr><h2>3. 残り時間表示の数理定義</h2><h3>残りミリ秒</h3><p>締切を $$T_{\text{deadline}}$$ とすると，</p><p>$$<br>D(t) = \max\left(0,; T_{\text{deadline}} - t_{\text{now}} \right)<br>$$</p><h3>表示秒数</h3><p>表示に用いる秒数 $$S$$ を</p><p>$$<br>S = \left\lfloor \frac{D(t)}{1000} \right\rfloor<br>$$</p><p>と定義する．</p><hr><h2>4. 描画抑制条件（不変条件）</h2><h3>状態変数</h3><p>$$<br>S_{\text{prev}} \in \mathbb{Z}_{\ge 0} \cup {\text{null}}<br>$$</p><h3>不変条件</h3><p>$$<br>S = S_{\text{prev}} ;\Rightarrow; \text{DOM更新を行わない}<br>$$</p><h3>結果</h3><ul><li><p>同一秒内での再描画回数は高々1回</p></li><li><p>色相更新（HSL）も同条件で抑制される</p></li><li><p>表示は「秒状態」に関して<strong>決定的</strong></p></li></ul><hr><h2>5. 長期ドリフト抑制（再アンカー）</h2><p>合成時刻モデルは理論上，</p><p>$$<br>t_{\text{now}} - \text{Date.now()} \approx \delta<br>$$</p><p>という誤差 $$\delta$$ を蓄積しうる．<br>これを抑えるため，以下を導入する．</p><h3>再同期条件</h3><p>$$<br>t_{\text{now}} - t_{\text{lastResync}} \ge 60000<br>$$</p><h3>操作</h3><p>$$<br>t_{\text{anchor}}^{\text{unix}} \leftarrow \text{Date.now()}<br>$$</p><p>$$<br>t_{\text{anchor}}^{\text{perf}} \leftarrow \text{performance.now()}<br>$$</p><p>これにより $$\delta$$ を周期的にリセットする．</p><hr><h2>実装対応表</h2>
数理概念 | 実装
-- | --
$$t_{\text{now}}$$ | App.clock.nowMs()
$$\Delta t = 1000 - (t \bmod 1000)$$ | calcNextBoundaryDelay()
$$S$$ | totalSeconds
$$S_{\text{prev}}$$ | lastTotalSeconds
再同期 | maybeResync()

<hr><h2>性質のまとめ（保証事項）</h2><ul><li><p>$$S$$ は単調非増加</p></li><li><p>秒境界近傍でのみ更新が起こる</p></li><li><p>$$S$$ が変化しない限り描画は発生しない</p></li><li><p>イベントループ遅延は次回更新で吸収される</p></li><li><p>長時間稼働でも時刻誤差は上界を持つ</p></li></ul><hr><h2>結論</h2><p>本PRは，タイマーを<br><strong>「時間を直接ポーリングするUI」</strong> から<br><strong>「秒状態に基づく決定的オートマトン」</strong><br>へと昇格させる変更である．</p><p>更新タイミング，表示値，描画回数のすべてが数式で定義可能となり，<br>環境依存の揺らぎは理論的に制御下に置かれている．</p></body></html>