### PR TITLE
fix: カウントダウンラベルを final presention までに変更

### DIFF
--- a/scripts/config.js
+++ b/scripts/config.js
@@ -8,7 +8,7 @@ App.config = {
   // constants.js の文字列を Date に変換して利用
   deadline: new Date(DEADLINE_TIME_TEXT),
   // 表示する任意テキスト
-  labelText: "❣️final presention までに❣️",
+  labelText: "❣️final presentation までに❣️",
   // フォントサイズの調整パラメータ
   fontScale: {
     min: 0.8,

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -8,7 +8,7 @@ App.config = {
   // constants.js の文字列を Date に変換して利用
   deadline: new Date(DEADLINE_TIME_TEXT),
   // 表示する任意テキスト
-  labelText: "❣️卒研発表まで❣️",
+  labelText: "❣️final presention までに❣️",
   // フォントサイズの調整パラメータ
   fontScale: {
     min: 0.8,


### PR DESCRIPTION
### Motivation
- 表示されるラベル文言が日本語の「卒研発表まで」になっていたため，英語表現の「final presention までに」へ変更する目的で修正を行いました．

### Description
- `scripts/config.js` の `App.config.labelText` を `"❣️卒研発表まで❣️"` から `"❣️final presention までに❣️"` に変更しました．
- 表示テキスト以外の挙動に影響が出ないよう，設定オブジェクトの他部分は変更していません．

### Testing
- `rg -n "labelText|final presention|卒研発表まで" scripts/config.js` で変更が反映されていることを確認しました，成功．
- `python -m http.server 8000` でローカル表示を立ち上げ，ブラウザ自動操作でスクリーンショットを取得して表示を目視確認しました，成功．

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992bbbc4e608327bc59843101b28e77)